### PR TITLE
Fixes fullstack dedupe-parser test

### DIFF
--- a/src/eponai/common/ui/store/dashboard.cljc
+++ b/src/eponai/common/ui/store/dashboard.cljc
@@ -130,7 +130,7 @@
                                    {:store.item/photos [{:store.item.photo/photo [:photo/path :photo/id]}
                                                         :store.item.photo/index]}
                                    {:store.item/skus [:db/id
-                                                      {:store.item.sku/inventory [:store.item.sku.inventory/value]}
+                                                      :store.item.sku/inventory
                                                       :store.item.sku/variation]}]}
                     {:stream/_store [:stream/state]}]}
      :query/current-route

--- a/src/eponai/web/ui/store/home.cljc
+++ b/src/eponai/web/ui/store/home.cljc
@@ -84,14 +84,15 @@
                     {:store/owners [{:store.owner/user [:user/email]}]}
                     :store/stripe
                     {:order/_store [:order/items]}
-                    :store/items
                     {:stream/_store [:stream/state]}]}
+     :query/store-item-count
      {:query/stripe-account [:stripe/details-submitted?]}
      :query/current-route])
   Object
   (render [this]
-    (let [{:query/keys [store current-route stripe-account]} (om/props this)
-          {:keys [store-id]} (:route-params current-route)]
+    (let [{:query/keys [store store-item-count current-route stripe-account]} (om/props this)
+          {:keys [store-id]} (:route-params current-route)
+          store-item-count (or store-item-count 0)]
       (dom/div
         {:id "sulo-main-dashboard"}
 
@@ -123,7 +124,7 @@
                 (grid/column
                   (css/text-align :center)
                   (dom/h3 nil "Products")
-                  (dom/p (css/add-class :stat) (count (:store/items store)))
+                  (dom/p (css/add-class :stat) store-item-count)
                   (button/default-hollow
                     {:href    (routes/url :store-dashboard/product-list {:store-id store-id})
                      :onClick #(mixpanel/track-key ::mixpanel/go-to-products {:source "store-dashboard"})}
@@ -171,7 +172,7 @@
               (dom/span nil "Describe your store. People love to hear your story."))
 
             (check-list-item
-              (boolean (not-empty (:store/items store)))
+              (boolean (pos? store-item-count))
               (routes/url :store-dashboard/create-product {:store-id store-id})
               (dom/span nil "Show off your amazing goods, add your first product."))
 

--- a/test/eponai/fullstack2/tests.clj
+++ b/test/eponai/fullstack2/tests.clj
@@ -251,7 +251,8 @@
         {:route-params {:user-id (get-id {:where '[[?e :user/email]]})}}))))
 
 (defn test-dedupe-parser-returns-super-set-of-original-parser []
-  (let [original (parser/client-parser (parser/client-parser-state {::parser/skip-dedupe true}))
+  (let [original (parser/client-parser (parser/client-parser-state {::parser/skip-dedupe true
+                                                                    ::parser/debug-reads true}))
         orig-parse (fn [reconciler]
                      (original (#'om/to-env reconciler) (om/get-query router/Router) nil))
         dedupe (parser/client-parser (parser/client-parser-state {::parser/skip-dedupe false}))
@@ -270,8 +271,9 @@
                              (data/diff (orig-parse reconciler)
                                         (dedupe-parse reconciler))]
                          (when (some? dedup)
-                           (info "Dedupe got something else: " dedupe))
+                           (info "Dedupe got something else: " dedup))
                          (when (some? orig)
+                           (debug "Route we fail on: " route)
                            {:type     :fail
                             :expected "dedupe parse to have at least everything that original parse had"
                             :actual   orig})))})]


### PR DESCRIPTION
isComponent attributes are tricky. They should
either always have a query or never have a query.

Dedupe parser is also able to handle different
remote queries from the initial key. For example
:query/store-item-count requires every item, so it
can return {:query/store [:store/items]} ast and
be merged with the :query/store reads.